### PR TITLE
Dev cutoff integration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+pandas>=0.21.0
+numpy>=1.13.0
+dill>=0.2.8.2
+python_dateutil>=2.6.0
+pytest>=3.3.2
+pytest-cov>=2.5.1
+py>=1.5.2
+scipy>=1.0.0
+featuretools
+matplotlib
+sklearn
+scikit-plot

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,6 +10,7 @@ sphinx_rtd_theme>=0.2.4
 
 # testing
 mock
+dill
 
 # style check
 flake8>=3.5.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,6 +8,9 @@ Sphinx>=1.7.1
 recommonmark>=0.4.0
 sphinx_rtd_theme>=0.2.4
 
+# testing
+mock
+
 # style check
 flake8>=3.5.0
 isort>=4.3.4

--- a/tests/core/test_cutoff_strategy.py
+++ b/tests/core/test_cutoff_strategy.py
@@ -1,8 +1,8 @@
 import unittest
 
-from mock import patch
 import numpy as np
 import pandas as pd
+from mock import patch
 
 from trane.core.cutoff_strategy import CutoffStrategy
 

--- a/tests/core/test_labeler.py
+++ b/tests/core/test_labeler.py
@@ -58,13 +58,15 @@ def test_labeler_apply():
 
     print(cutoff_df)
 
+    operations = [
+        AllFilterOp(label_generating_column),
+        IdentityRowOp(label_generating_column),
+        IdentityTransformationOp(label_generating_column),
+        LastAggregationOp(label_generating_column)]
+
     prediction_problem = PredictionProblem(
-        [AllFilterOp(label_generating_column),
-         IdentityRowOp(
-            label_generating_column),
-         IdentityTransformationOp(
-            label_generating_column),
-         LastAggregationOp(label_generating_column)])
+        operations=operations,
+        cutoff_strategy=None)
 
     (is_valid_prediction_problem,
         filter_column_order_of_types,

--- a/tests/core/test_prediction_problem.py
+++ b/tests/core/test_prediction_problem.py
@@ -1,7 +1,7 @@
 import unittest
 
-from mock import patch
 import pandas as pd
+from mock import patch
 
 from trane.core.prediction_problem import *  # noqa
 from trane.core.prediction_problem import entropy_of_a_list

--- a/tests/core/test_prediction_problem.py
+++ b/tests/core/test_prediction_problem.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 
 import pandas as pd
@@ -304,6 +305,32 @@ class TestPredictionProblemMethods(unittest.TestCase):
         self.assertTrue(to_json_patch.called)
         self.assertTrue(dill_cutoff_strategy_patch.called)
         self.assertTrue(os_path_exists_patch.called)
+
+    def test_load(self):
+        self.assertIsNotNone(PredictionProblem.load)
+
+        open_patch = None
+        if (sys.version_info > (3, 0)):
+            open_patch = self.create_patch('builtins.open')
+        else:
+            open_patch = self.create_patch('__builtin__.open')
+
+        json_patch = self.create_patch(
+            'trane.core.prediction_problem.json')
+        from_json_patch = self.create_patch(
+            'trane.core.PredictionProblem.from_json')
+        os_path_patch = self.create_patch(
+            'trane.core.prediction_problem.os.path')
+        dill_patch = self.create_patch(
+            'trane.core.prediction_problem.dill')
+
+        PredictionProblem.load('filepath.json')
+        self.assertTrue(open_patch.called)
+        self.assertTrue(json_patch.load.called)
+        self.assertTrue(from_json_patch.called)
+        self.assertTrue(os_path_patch.join.called)
+        self.assertTrue(os_path_patch.dirname.called)
+        self.assertTrue(dill_patch.load.called)
 
     def test_dill_cutoff_strategy(self):
         self.assertIsNotNone(self.problem._dill_cutoff_strategy)

--- a/tests/core/test_prediction_problem.py
+++ b/tests/core/test_prediction_problem.py
@@ -1,3 +1,6 @@
+import unittest
+
+from mock import patch
 import pandas as pd
 
 from trane.core.prediction_problem import *  # noqa
@@ -226,3 +229,29 @@ def test_entropy():
     assert(entropy_b == 1.9061547465398496)
     assert(entropy_c == 0.0)
     assert(entropy_d == 0.6931471805599453)
+
+
+class TestPredictionProblemMethods(unittest.TestCase):
+    def setUp(self):
+        mock_op = self.create_patch(
+            'trane.ops.OpBase')
+        operations = [mock_op for x in range(4)]
+
+        mock_cutoff_strategy = self.create_patch(
+            'trane.core.CutoffStrategy')
+
+        self.problem = PredictionProblem(
+            operations=operations, cutoff_strategy=mock_cutoff_strategy)
+
+    def create_patch(self, name):
+        # helper method for creating patches
+        patcher = patch(name)
+        thing = patcher.start()
+        self.addCleanup(patcher.stop)
+        return thing
+
+    def test_cutoff_strategy_exists(self):
+        self.assertIsNotNone(self.problem.cutoff_strategy)
+
+    def test_generate_cutoffs_method_exists(self):
+        self.assertIsNotNone(self.problem.generate_cutoffs)

--- a/tests/core/test_prediction_problem.py
+++ b/tests/core/test_prediction_problem.py
@@ -278,6 +278,33 @@ class TestPredictionProblemMethods(unittest.TestCase):
     def test_to_json_exists(self):
         self.assertIsNotNone(self.problem.to_json)
 
+    def test_save(self):
+        self.assertIsNotNone(self.problem.save)
+
+        pickle_cutoff_strategy_patch = self.create_patch(
+            'trane.core.PredictionProblem._pickle_cutoff_strategy')
+        os_path_exists_patch = self.create_patch(
+            'trane.core.prediction_problem.os.path.exists')
+        os_path_exists_patch.return_value = False
+        to_json_patch = self.create_patch(
+            'trane.core.PredictionProblem.to_json')
+        pickle_cutoff_strategy_patch = self.create_patch(
+            'trane.core.PredictionProblem._pickle_cutoff_strategy')
+
+        path = '../Data'
+        problem_name = 'problem_name'
+
+        try:
+            self.problem.save(path=path, problem_name=problem_name)
+        except Exception as e:
+            print('test_save doesn\'t test i/o. '
+                  'This exception statement catches the error.')
+            print(e)
+
+        self.assertTrue(to_json_patch.called)
+        self.assertTrue(pickle_cutoff_strategy_patch.called)
+        self.assertTrue(os_path_exists_patch.called)
+
     def test_pickle_cutoff_strategy(self):
         self.assertIsNotNone(self.problem._pickle_cutoff_strategy)
         cutoff_pickle = self.problem._pickle_cutoff_strategy()

--- a/tests/core/test_prediction_problem.py
+++ b/tests/core/test_prediction_problem.py
@@ -237,14 +237,17 @@ class TestPredictionProblemMethods(unittest.TestCase):
             'trane.ops.OpBase')
         operations = [mock_op for x in range(4)]
 
-        mock_cutoff_strategy = self.create_patch(
+        self.mock_cutoff_strategy = self.create_patch(
             'trane.core.CutoffStrategy')
 
         self.entity_col = 'entity_col'
 
         self.problem = PredictionProblem(
             operations=operations, entity_id_col=self.entity_col,
-            cutoff_strategy=mock_cutoff_strategy)
+            cutoff_strategy=self.mock_cutoff_strategy)
+
+        self.mock_pickle = self.create_patch(
+            'trane.core.prediction_problem.pickle')
 
     def create_patch(self, name):
         # helper method for creating patches
@@ -271,3 +274,13 @@ class TestPredictionProblemMethods(unittest.TestCase):
         self.assertTrue(
             self.entity_col in
             self.problem.cutoff_strategy.generate_cutoffs.call_args[0])
+
+    def test_to_json_exists(self):
+        self.assertIsNotNone(self.problem.to_json)
+
+    def test_pickle_cutoff_strategy(self):
+        self.assertIsNotNone(self.problem._pickle_cutoff_strategy)
+        cutoff_pickle = self.problem._pickle_cutoff_strategy()
+
+        self.assertEqual(
+            cutoff_pickle, self.mock_pickle.dumps(self.mock_cutoff_strategy))

--- a/tests/core/test_prediction_problem.py
+++ b/tests/core/test_prediction_problem.py
@@ -240,8 +240,11 @@ class TestPredictionProblemMethods(unittest.TestCase):
         mock_cutoff_strategy = self.create_patch(
             'trane.core.CutoffStrategy')
 
+        self.entity_col = 'entity_col'
+
         self.problem = PredictionProblem(
-            operations=operations, cutoff_strategy=mock_cutoff_strategy)
+            operations=operations, entity_id_col=self.entity_col,
+            cutoff_strategy=mock_cutoff_strategy)
 
     def create_patch(self, name):
         # helper method for creating patches
@@ -253,5 +256,18 @@ class TestPredictionProblemMethods(unittest.TestCase):
     def test_cutoff_strategy_exists(self):
         self.assertIsNotNone(self.problem.cutoff_strategy)
 
+    def entity_id_col_exists(self):
+        self.assertIsNot(self.problem.entity_id_col)
+
     def test_generate_cutoffs_method_exists(self):
         self.assertIsNotNone(self.problem.generate_cutoffs)
+
+    def test_generate_cutoffs_method_calls_cutoff_strategy_gen_cutoffs(self):
+        self.problem.generate_cutoffs(df=None)
+
+        self.assertTrue(self.problem.cutoff_strategy.generate_cutoffs.called)
+
+        # entity_column passed?
+        self.assertTrue(
+            self.entity_col in
+            self.problem.cutoff_strategy.generate_cutoffs.call_args[0])

--- a/tests/core/test_prediction_problem.py
+++ b/tests/core/test_prediction_problem.py
@@ -246,8 +246,8 @@ class TestPredictionProblemMethods(unittest.TestCase):
             operations=operations, entity_id_col=self.entity_col,
             cutoff_strategy=self.mock_cutoff_strategy)
 
-        self.mock_pickle = self.create_patch(
-            'trane.core.prediction_problem.pickle')
+        self.mock_dill = self.create_patch(
+            'trane.core.prediction_problem.dill')
 
     def create_patch(self, name):
         # helper method for creating patches
@@ -281,15 +281,15 @@ class TestPredictionProblemMethods(unittest.TestCase):
     def test_save(self):
         self.assertIsNotNone(self.problem.save)
 
-        pickle_cutoff_strategy_patch = self.create_patch(
-            'trane.core.PredictionProblem._pickle_cutoff_strategy')
+        dill_cutoff_strategy_patch = self.create_patch(
+            'trane.core.PredictionProblem._dill_cutoff_strategy')
         os_path_exists_patch = self.create_patch(
             'trane.core.prediction_problem.os.path.exists')
         os_path_exists_patch.return_value = False
         to_json_patch = self.create_patch(
             'trane.core.PredictionProblem.to_json')
-        pickle_cutoff_strategy_patch = self.create_patch(
-            'trane.core.PredictionProblem._pickle_cutoff_strategy')
+        dill_cutoff_strategy_patch = self.create_patch(
+            'trane.core.PredictionProblem._dill_cutoff_strategy')
 
         path = '../Data'
         problem_name = 'problem_name'
@@ -302,12 +302,12 @@ class TestPredictionProblemMethods(unittest.TestCase):
             print(e)
 
         self.assertTrue(to_json_patch.called)
-        self.assertTrue(pickle_cutoff_strategy_patch.called)
+        self.assertTrue(dill_cutoff_strategy_patch.called)
         self.assertTrue(os_path_exists_patch.called)
 
-    def test_pickle_cutoff_strategy(self):
-        self.assertIsNotNone(self.problem._pickle_cutoff_strategy)
-        cutoff_pickle = self.problem._pickle_cutoff_strategy()
+    def test_dill_cutoff_strategy(self):
+        self.assertIsNotNone(self.problem._dill_cutoff_strategy)
+        cutoff_dill = self.problem._dill_cutoff_strategy()
 
         self.assertEqual(
-            cutoff_pickle, self.mock_pickle.dumps(self.mock_cutoff_strategy))
+            cutoff_dill, self.mock_dill.dumps(self.mock_cutoff_strategy))

--- a/tests/core/test_prediction_problem.py
+++ b/tests/core/test_prediction_problem.py
@@ -38,15 +38,16 @@ def test_hyper_parameter_generation():
     label_generating_column = "fare"
     filter_column = "taxi_id"
     entity_id_column = "taxi_id"
-    prediction_problem = PredictionProblem([GreaterFilterOp(filter_column),
-                                            GreaterRowOp(
-        label_generating_column),
-        IdentityTransformationOp(
-        label_generating_column),
-        LastAggregationOp(label_generating_column)])
-    prediction_problem.generate_and_set_hyper_parameters(dataframe,
-                                                         label_generating_column, filter_column,
-                                                         entity_id_column)
+
+    operations = [GreaterFilterOp(filter_column),
+                  GreaterRowOp(label_generating_column),
+                  IdentityTransformationOp(label_generating_column),
+                  LastAggregationOp(label_generating_column)]
+
+    prediction_problem = PredictionProblem(
+        operations=operations, cutoff_strategy=None)
+    prediction_problem.generate_and_set_hyper_parameters(
+        dataframe, label_generating_column, filter_column, entity_id_column)
 
     op1_hyper_parameter = prediction_problem.operations[0].hyper_parameter_settings
     op2_hyper_parameter = prediction_problem.operations[1].hyper_parameter_settings
@@ -75,16 +76,16 @@ def test_hashing_collisions():
 def test_hyper_parameter_generation_2():
     label_generating_column = "c1"
     filter_column = "c2"
+    operations = [GreaterFilterOp(filter_column),
+                  GreaterRowOp(label_generating_column),
+                  IdentityTransformationOp(label_generating_column),
+                  LastAggregationOp(label_generating_column)]
 
-    prediction_problem = PredictionProblem([GreaterFilterOp(filter_column),
-                                            GreaterRowOp(
-        label_generating_column),
-        IdentityTransformationOp(
-        label_generating_column),
-        LastAggregationOp(label_generating_column)])
-    prediction_problem.generate_and_set_hyper_parameters(dataframe2,
-                                                         label_generating_column, filter_column,
-                                                         entity_id_column="c1")
+    prediction_problem = PredictionProblem(
+        operations=operations, cutoff_strategy=None)
+    prediction_problem.generate_and_set_hyper_parameters(
+        dataframe2, label_generating_column, filter_column,
+        entity_id_column="c1")
 
     op1_hyper_parameter = prediction_problem.operations[0].hyper_parameter_settings
     op2_hyper_parameter = prediction_problem.operations[1].hyper_parameter_settings
@@ -100,22 +101,22 @@ def test_hyper_parameter_generation_2():
 def test_op_type_check():
     filter_column = "fare"
     label_generating_column = "fare"
+    operations = [AllFilterOp(filter_column),
+                  IdentityRowOp(label_generating_column),
+                  IdentityTransformationOp(label_generating_column),
+                  LastAggregationOp(label_generating_column)]
     table_meta = TableMeta.from_json(json_str)
 
-    prediction_problem_correct_types = PredictionProblem([AllFilterOp(filter_column),
-                                                          IdentityRowOp(
-        label_generating_column),
-        IdentityTransformationOp(
-        label_generating_column),
-        LastAggregationOp(label_generating_column)])
+    prediction_problem_correct_types = PredictionProblem(
+        operations=operations, cutoff_strategy=None)
 
     label_generating_column = "vendor_id"
-    prediction_problem_incorrect_types = PredictionProblem([AllFilterOp(filter_column),
-                                                            IdentityRowOp(
-        label_generating_column),
-        IdentityTransformationOp(
-        label_generating_column),
-        LMFAggregationOp(label_generating_column)])
+    operations = [AllFilterOp(filter_column),
+                  IdentityRowOp(label_generating_column),
+                  IdentityTransformationOp(label_generating_column),
+                  LMFAggregationOp(label_generating_column)]
+    prediction_problem_incorrect_types = PredictionProblem(
+        operations=operations, cutoff_strategy=None)
 
     (
         correct_is_valid,
@@ -149,13 +150,13 @@ def test_execute():
 
     time_column = "trip_id"
     cutoff_time = 100
+    operations = [AllFilterOp(label_generating_column),
+                  IdentityRowOp(label_generating_column),
+                  IdentityTransformationOp(label_generating_column),
+                  LastAggregationOp(label_generating_column)]
 
-    prediction_problem = PredictionProblem([AllFilterOp(label_generating_column),
-                                            IdentityRowOp(
-        label_generating_column),
-        IdentityTransformationOp(
-        label_generating_column),
-        LastAggregationOp(label_generating_column)])
+    prediction_problem = PredictionProblem(
+        operations=operations, cutoff_strategy=None)
 
     expected = 41.35
     precutoff_time, all_data = prediction_problem.execute(
@@ -167,12 +168,12 @@ def test_execute():
 
 def test_to_and_from_json():
     label_generating_column = "fare"
-    prediction_problem = PredictionProblem([AllFilterOp(label_generating_column),
-                                            IdentityRowOp(
-        label_generating_column),
-        IdentityTransformationOp(
-        label_generating_column),
-        LastAggregationOp(label_generating_column)])
+    operations = [AllFilterOp(label_generating_column),
+                  IdentityRowOp(label_generating_column),
+                  IdentityTransformationOp(label_generating_column),
+                  LastAggregationOp(label_generating_column)]
+    prediction_problem = PredictionProblem(
+        operations=operations, cutoff_strategy=None)
     json_str = prediction_problem.to_json()
     prediction_problem_from_json = PredictionProblem.from_json(json_str)
 
@@ -181,12 +182,12 @@ def test_to_and_from_json():
 
 def test_to_and_from_json_with_order_of_types():
     label_generating_column = "fare"
-    prediction_problem = PredictionProblem([AllFilterOp(label_generating_column),
-                                            IdentityRowOp(
-        label_generating_column),
-        IdentityTransformationOp(
-        label_generating_column),
-        LastAggregationOp(label_generating_column)])
+    operations = [AllFilterOp(label_generating_column),
+                  IdentityRowOp(label_generating_column),
+                  IdentityTransformationOp(label_generating_column),
+                  LastAggregationOp(label_generating_column)]
+    prediction_problem = PredictionProblem(
+        operations=operations, cutoff_strategy=None)
     prediction_problem.filter_column_order_of_types = [TableMeta.TYPE_INTEGER]
     prediction_problem.label_generating_column_order_of_types = \
         [TableMeta.TYPE_INTEGER, TableMeta.TYPE_BOOL, TableMeta.TYPE_CATEGORY]
@@ -198,18 +199,14 @@ def test_to_and_from_json_with_order_of_types():
 
 def test_equality():
     label_generating_column = "fare"
-    prediction_problem = PredictionProblem([AllFilterOp(label_generating_column),
-                                            IdentityRowOp(
-        label_generating_column),
-        IdentityTransformationOp(
-        label_generating_column),
-        LastAggregationOp(label_generating_column)])
-    prediction_problem_clone = PredictionProblem([AllFilterOp(label_generating_column),
-                                                  IdentityRowOp(
-        label_generating_column),
-        IdentityTransformationOp(
-        label_generating_column),
-        LastAggregationOp(label_generating_column)])
+    operations = [AllFilterOp(label_generating_column),
+                  IdentityRowOp(label_generating_column),
+                  IdentityTransformationOp(label_generating_column),
+                  LastAggregationOp(label_generating_column)]
+    prediction_problem = PredictionProblem(
+        operations=operations, cutoff_strategy=None)
+    prediction_problem_clone = PredictionProblem(
+        operations=operations, cutoff_strategy=None)
 
     assert(prediction_problem_clone == prediction_problem)
 

--- a/tests/core/test_prediction_problem_saver.py
+++ b/tests/core/test_prediction_problem_saver.py
@@ -29,16 +29,17 @@ def test_write_then_read():
     entity_id_column = "taxi_id"
     time_column = "trip_id"
     label_generating_column = "fare"
-    prediction_problem = PredictionProblem([AllFilterOp(label_generating_column),
-                                            IdentityRowOp(
-                                                label_generating_column),
-                                            IdentityTransformationOp(
-                                                label_generating_column),
-                                            LastAggregationOp(label_generating_column)])
+    operations = [AllFilterOp(label_generating_column),
+                  IdentityRowOp(label_generating_column),
+                  IdentityTransformationOp(label_generating_column),
+                  LastAggregationOp(label_generating_column)]
+    prediction_problem = PredictionProblem(
+        operations=operations, cutoff_strategy=None)
     filename = "prediction_problem.json"
 
-    prediction_problems_to_json_file([prediction_problem], table_meta, entity_id_column,
-                                     label_generating_column, time_column, filename)
+    prediction_problems_to_json_file(
+        [prediction_problem], table_meta, entity_id_column,
+        label_generating_column, time_column, filename)
 
     prediction_problems_from_json, table_meta_from_json, entity_id_column_from_json, \
         label_generating_column_from_json, time_column_from_json = prediction_problems_from_json_file(

--- a/tests/utils/test_cutoff_strategy.py
+++ b/tests/utils/test_cutoff_strategy.py
@@ -1,72 +1,71 @@
+import unittest
+
+from mock import patch
 import numpy as np
 import pandas as pd
 
 from trane.core.cutoff_strategy import CutoffStrategy
 
 
-def test_fixed_cutoff_time():
-    def generate_fn(entity_id, group):
-        training_cutoff = np.datetime64('1980-02-25')
-        test_cutoff = np.datetime64('2000-02-25')
-        return((training_cutoff, test_cutoff))
+class TestCutoffStrategy(unittest.TestCase):
+    def setUp(self):
 
-    cutoff_strategy = CutoffStrategy(
-        generate_fn=generate_fn,
-        description='foo description')
+        self.description = 'a description'
 
-    test_data = pd.DataFrame(
-        data=np.arange(90).reshape(-1, 3),
-        columns=['entity_id', 'other_data', 'other_data_2'])
+        def generate_fn(entity_id, group):
 
-    cutoff_df = cutoff_strategy.generate_cutoffs(
-        df=test_data, entity_id_col='entity_id')
+            # test_cutoff is 5 days after first row's date
+            # import pdb; pdb.set_trace()
+            date_of_first_row = group.iloc[0].dates
+            test_cutoff = date_of_first_row - np.timedelta64(5, 'D')
 
-    # no variance in training_cutoff or test_cutoff columns
-    assert len(cutoff_df.training_cutoff.unique()) == 1
-    assert len(cutoff_df.test_cutoff.unique()) == 1
+            # training_cutoff is constant
+            training_cutoff = np.datetime64('1980-02-25')
 
-    assert cutoff_df.training_cutoff.unique()[0] == np.datetime64('1980-02-25')
-    assert cutoff_df.test_cutoff.unique()[0] == np.datetime64('2000-02-25')
+            return((training_cutoff, test_cutoff))
+        self.generate_fn = generate_fn
 
-    assert cutoff_strategy.description == 'foo description'
+        self.cutoff_strategy = CutoffStrategy(
+            generate_fn=self.generate_fn, description=self.description)
 
+    def create_patch(self, name):
+        # helper method for creating patches
+        patcher = patch(name)
+        thing = patcher.start()
+        self.addCleanup(patcher.stop)
+        return thing
 
-def test_dynamic_cutoff_time():
-    def generate_fn(entity_id, group):
+    def test_generate_fn_assigned(self):
+        self.assertEqual(self.generate_fn, self.cutoff_strategy.generate_fn)
 
-        # test_cutoff is 5 days after first row's date
-        # import pdb; pdb.set_trace()
-        date_of_first_row = group.iloc[0].dates
-        test_cutoff = date_of_first_row - np.timedelta64(5, 'D')
+    def test_description_assigned(self):
+        self.assertEqual(self.description, self.cutoff_strategy.description)
 
-        # training_cutoff is constant
-        training_cutoff = np.datetime64('1980-02-25')
+    def test_cutoff_times_returned_as_expected(self):
+        # this is more of an integration test than a unittest, really
 
-        return((training_cutoff, test_cutoff))
+        data = {'entity_id': ['a', 'a', 'b'],
+                'dates': [
+                    np.datetime64('1980-02-25'),
+                    np.datetime64('1980-02-24'),
+                    np.datetime64('1980-02-23')],
+                'other_col': ['d', 'e', 'f']}
+        test_data = pd.DataFrame(data)
 
-    cutoff_strategy = CutoffStrategy(
-        generate_fn=generate_fn,
-        description='foo description')
+        cutoff_df = self.cutoff_strategy.generate_cutoffs(
+            df=test_data, entity_id_col='entity_id')
 
-    data = {'entity_id': ['a', 'a', 'b'],
-            'dates': [
-                np.datetime64('1980-02-25'),
-                np.datetime64('1980-02-24'),
-                np.datetime64('1980-02-23')],
-            'other_col': ['d', 'e', 'f']}
+        # no variance in training_cutoff columns
+        self.assertEqual(len(cutoff_df.training_cutoff.unique()), 1)
+        self.assertEqual(
+            cutoff_df.training_cutoff.unique()[0],
+            np.datetime64('1980-02-25'))
 
-    test_data = pd.DataFrame(data)
+        # test_cutoff should be a different date
+        self.assertEqual(
+            cutoff_df.loc['a'].test_cutoff,
+            np.datetime64('1980-02-20'))
 
-    cutoff_df = cutoff_strategy.generate_cutoffs(
-        df=test_data, entity_id_col='entity_id')
-
-    # no variance in training_cutoff columns
-    assert len(cutoff_df.training_cutoff.unique()) == 1
-    assert cutoff_df.training_cutoff.unique()[0] == np.datetime64('1980-02-25')
-
-    # test_cutoff should be a different date
-    assert cutoff_df.loc['a'].test_cutoff == np.datetime64('1980-02-20')
-    assert cutoff_df.loc['b'].test_cutoff == np.datetime64('1980-02-18')
-
-    # description should be the same
-    assert cutoff_strategy.description == 'foo description'
+        self.assertEqual(
+            cutoff_df.loc['b'].test_cutoff,
+            np.datetime64('1980-02-18'))

--- a/tox.ini
+++ b/tox.ini
@@ -23,9 +23,9 @@ commands =
 
 
 [testenv:flake8]
+skipsdist = true
 deps =
-    flake8
-    isort
+    -r{toxinidir}/requirements_dev.txt
 commands =
     /usr/bin/env make lint
 

--- a/trane/core/cutoff_strategy.py
+++ b/trane/core/cutoff_strategy.py
@@ -25,7 +25,8 @@ class CutoffStrategy:
     def generate_cutoffs(self, df, entity_id_col):
         """
         generate a cutoff dataframe. Takes about 10 sec to load, but then runs
-        inNlogN time.
+        inNlogN time. (probably. Haven't checked numpy and pandas code. That's
+        just what anecdotally seen in testing)
 
         Parameters
         ----------

--- a/trane/core/prediction_problem.py
+++ b/trane/core/prediction_problem.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import pickle
 import random
 import time
 import warnings
@@ -318,6 +319,10 @@ class PredictionProblem:
         problem.label_generating_column_order_of_types = data[
             'label_generating_column_order_of_types']
         return problem
+
+    def _pickle_cutoff_strategy(self):
+        cutoff_pickle = pickle.dumps(self.cutoff_strategy)
+        return cutoff_pickle
 
     def __eq__(self, other):
         """Overrides the default implementation"""

--- a/trane/core/prediction_problem.py
+++ b/trane/core/prediction_problem.py
@@ -2,6 +2,8 @@ import json
 import logging
 import random
 import time
+import warnings
+
 from collections import Counter
 
 import numpy as np
@@ -36,6 +38,14 @@ class PredictionProblem:
         self.cutoff_strategy = cutoff_strategy
         self.filter_column_order_of_types = None
         self.label_generating_column_order_of_types = None
+
+    def generate_cutoffs(self):
+        if self.cutoff_strategy is None:
+            warnings.warn(
+                "Problem cutoff strategy not specified. Returning None",
+                RuntimeWarning)
+            return None
+
 
     def is_valid_prediction_problem(
             self, table_meta, filter_column, label_generating_column):

--- a/trane/core/prediction_problem.py
+++ b/trane/core/prediction_problem.py
@@ -23,7 +23,7 @@ class PredictionProblem:
     each operation.
     """
 
-    def __init__(self, operations, cutoff_strategy=None):
+    def __init__(self, operations, entity_id_col=None, cutoff_strategy=None):
         """
         Parameters
         ----------
@@ -35,16 +35,19 @@ class PredictionProblem:
         None
         """
         self.operations = operations
+        self.entity_id_col = entity_id_col
         self.cutoff_strategy = cutoff_strategy
         self.filter_column_order_of_types = None
         self.label_generating_column_order_of_types = None
 
-    def generate_cutoffs(self):
+    def generate_cutoffs(self, df):
         if self.cutoff_strategy is None:
             warnings.warn(
                 "Problem cutoff strategy not specified. Returning None",
                 RuntimeWarning)
             return None
+
+        return self.cutoff_strategy.generate_cutoffs(df, self.entity_id_col)
 
 
     def is_valid_prediction_problem(

--- a/trane/core/prediction_problem.py
+++ b/trane/core/prediction_problem.py
@@ -4,7 +4,6 @@ import pickle
 import random
 import time
 import warnings
-
 from collections import Counter
 
 import numpy as np

--- a/trane/core/prediction_problem.py
+++ b/trane/core/prediction_problem.py
@@ -21,17 +21,19 @@ class PredictionProblem:
     each operation.
     """
 
-    def __init__(self, operations):
+    def __init__(self, operations, cutoff_strategy=None):
         """
         Parameters
         ----------
         operations: list of Operations of type op_base
+        cutoff_strategy: a CutoffStrategy object
 
         Returns
         -------
         None
         """
         self.operations = operations
+        self.cutoff_strategy = cutoff_strategy
         self.filter_column_order_of_types = None
         self.label_generating_column_order_of_types = None
 
@@ -298,7 +300,7 @@ class PredictionProblem:
         data = json.loads(json_data)
         operations = [op_from_json(json.dumps(item))
                       for item in data['operations']]
-        problem = PredictionProblem(operations)
+        problem = PredictionProblem(operations, cutoff_strategy=None)
         problem.filter_column_order_of_types = data[
             'filter_column_order_of_types']
         problem.label_generating_column_order_of_types = data[

--- a/trane/core/prediction_problem.py
+++ b/trane/core/prediction_problem.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import os
-import pickle
+import dill
 import random
 import time
 import warnings
@@ -282,7 +282,7 @@ class PredictionProblem:
         '''
         Saves the pediction problem in two files.
 
-        One file is a pickle of the cutoff strategy.
+        One file is a dill of the cutoff strategy.
         The other file is the jsonified operations and the relative path to
         that cutoff strategy.
 
@@ -301,7 +301,7 @@ class PredictionProblem:
 
         '''
         json_saved = False
-        pickle_saved = False
+        dill_saved = False
         created_directory = False
 
         # create directory if it doesn't exist
@@ -312,36 +312,36 @@ class PredictionProblem:
         # rename the problem_name if already exists
         json_file_exists = os.path.exists(
             os.path.join(path, problem_name + '.json'))
-        pickle_file_exists = os.path.exists(
-            os.path.join(path, problem_name + 'pkl'))
+        dill_file_exists = os.path.exists(
+            os.path.join(path, problem_name + '.dill'))
 
         i = 1
-        while json_file_exists or pickle_file_exists:
+        while json_file_exists or dill_file_exists:
             problem_name += str(i)
 
             i += 1
             json_file_exists = os.path.exists(
                 os.path.join(path, problem_name + '.json'))
-            pickle_file_exists = os.path.exists(
-                os.path.join(path, problem_name + 'pkl'))
+            dill_file_exists = os.path.exists(
+                os.path.join(path, problem_name + '.dill'))
 
         # get the cutoff_strategy bytes
-        cutoff_pickle_bytes = self._pickle_cutoff_strategy()
+        cutoff_dill_bytes = self._dill_cutoff_strategy()
 
         # add a key to the problem json
         json_dict = json.loads(self.to_json())
-        json_dict['cutoff_pickle'] = problem_name + '.pkl'
+        json_dict['cutoff_dill'] = problem_name + '.dill'
 
         # write the files
         with open(os.path.join(path, problem_name + '.json'), 'w') as f:
             json.dump(obj=json_dict, fp=f, indent=4, sort_keys=True)
             json_saved = True
 
-        with open(os.path.join(path, problem_name + '.pkl'), 'wb') as f:
-            f.write(cutoff_pickle_bytes)
-            pickle_saved = True
+        with open(os.path.join(path, problem_name + '.dill'), 'wb') as f:
+            f.write(cutoff_dill_bytes)
+            dill_saved = True
 
-        return({'saved_correctly': json_saved & pickle_saved,
+        return({'saved_correctly': json_saved & dill_saved,
                 'created_directory': created_directory,
                 'problem_name': problem_name})
 
@@ -390,9 +390,9 @@ class PredictionProblem:
             'label_generating_column_order_of_types']
         return problem
 
-    def _pickle_cutoff_strategy(self):
+    def _dill_cutoff_strategy(self):
         '''
-        Function creates a pickle for the problem's associated cutoff strategy
+        Function creates a dill for the problem's associated cutoff strategy
 
         This function requires cutoff time to be assigned.
 
@@ -401,10 +401,10 @@ class PredictionProblem:
 
         Returns
         -------
-        a pickle of the cutoff strategy
+        a dill of the cutoff strategy
         '''
-        cutoff_pickle = pickle.dumps(self.cutoff_strategy)
-        return cutoff_pickle
+        cutoff_dill = dill.dumps(self.cutoff_strategy)
+        return cutoff_dill
 
     def __eq__(self, other):
         """Overrides the default implementation"""

--- a/trane/core/prediction_problem.py
+++ b/trane/core/prediction_problem.py
@@ -49,7 +49,6 @@ class PredictionProblem:
 
         return self.cutoff_strategy.generate_cutoffs(df, self.entity_id_col)
 
-
     def is_valid_prediction_problem(
             self, table_meta, filter_column, label_generating_column):
         """

--- a/trane/core/prediction_problem_generator.py
+++ b/trane/core/prediction_problem_generator.py
@@ -81,7 +81,7 @@ class PredictionProblemGenerator:
                 transformation_op_obj,
                 aggregation_op_obj]
 
-            prediction_problem = PredictionProblem(operations)
+            prediction_problem = PredictionProblem(operations, cutoff_strategy=None)
 
             logging.debug("prediction problem generated, now checking validity...")
 


### PR DESCRIPTION
- Fix flake8 tox testing
- Write new tests for prediction problem
- Consolidate cutoff_strategy tests
- allow PredictionProblem to be assigned a CutoffStrategy
- Save and load prediction problems and their associated cutoff strategies