### PR TITLE
Dev update execute for single cutoff

### DIFF
--- a/tests/core/test_cutoff_strategy.py
+++ b/tests/core/test_cutoff_strategy.py
@@ -14,14 +14,11 @@ class TestCutoffStrategy(unittest.TestCase):
 
         def generate_fn(group, entity_id):
 
-            # test_cutoff is 5 days after first row's date
+            # cutoff is 5 days after first row's date
             date_of_first_row = group.iloc[0].dates
-            test_cutoff = date_of_first_row - np.timedelta64(5, 'D')
+            cutoff = date_of_first_row + np.timedelta64(5, 'D')
 
-            # training_cutoff is constant
-            training_cutoff = np.datetime64('1980-02-25')
-
-            return((training_cutoff, test_cutoff))
+            return(cutoff)
         self.generate_fn = generate_fn
 
         self.cutoff_strategy = CutoffStrategy(
@@ -45,29 +42,23 @@ class TestCutoffStrategy(unittest.TestCase):
 
         data = {'entity_id': ['a', 'a', 'b'],
                 'dates': [
-                    np.datetime64('1980-02-25'),
+                    np.datetime64('1980-02-01'),
                     np.datetime64('1980-02-24'),
-                    np.datetime64('1980-02-23')],
+                    np.datetime64('1980-03-01')],
                 'other_col': ['d', 'e', 'f']}
         test_data = pd.DataFrame(data)
 
         cutoff_df = self.cutoff_strategy.generate_cutoffs(
             df=test_data, entity_id_col='entity_id')
 
-        # no variance in training_cutoff columns
-        self.assertEqual(len(cutoff_df.training_cutoff.unique()), 1)
-        self.assertEqual(
-            cutoff_df.training_cutoff.unique()[0],
-            np.datetime64('1980-02-25'))
-
         # test_cutoff should be a different date
         self.assertEqual(
-            cutoff_df.loc['a'].test_cutoff,
-            np.datetime64('1980-02-20'))
+            cutoff_df.loc['a'].cutoff,
+            np.datetime64('1980-02-06'))
 
         self.assertEqual(
-            cutoff_df.loc['b'].test_cutoff,
-            np.datetime64('1980-02-18'))
+            cutoff_df.loc['b'].cutoff,
+            np.datetime64('1980-03-06'))
 
     def test_cutoff_times_returned_as_expected_without_cutoff_strategy(self):
         # this is more of an integration test than a unittest, really
@@ -86,11 +77,10 @@ class TestCutoffStrategy(unittest.TestCase):
         cutoff_df = self.cutoff_strategy.generate_cutoffs(
             df=test_data, entity_id_col='entity_id')
 
-        # no variance in training and test_cutoff columns
-        self.assertEqual(len(cutoff_df.training_cutoff.unique()), 1)
-        self.assertEqual(len(cutoff_df.test_cutoff.unique()), 1)
+        # no variance in cutoff columns
+        self.assertEqual(len(cutoff_df.cutoff.unique()), 1)
 
         # training and test cutoff should both be None
-        self.assertEqual(cutoff_df.loc['a'].test_cutoff, None)
+        self.assertEqual(cutoff_df.loc['a'].cutoff, None)
 
-        self.assertEqual(cutoff_df.loc['b'].test_cutoff, None)
+        self.assertEqual(cutoff_df.loc['b'].cutoff, None)

--- a/tests/core/test_prediction_problem.py
+++ b/tests/core/test_prediction_problem.py
@@ -338,7 +338,7 @@ class TestPredictionProblemMethods(unittest.TestCase):
 
         res = self.problem.execute(df)
         self.assertEqual(res.columns.tolist(), ['cutoff', 'label'])
-        self.assertEqual(res.index.tolist(), [100, 200])
+        self.assertEqual(set(res.index.tolist()), set([100, 200]))
         self.assertEqual(res.loc[100]['label'], 0)
         self.assertEqual(res.loc[200]['label'], 0)
 
@@ -412,6 +412,3 @@ class TestPredictionProblemMethods(unittest.TestCase):
 
         description = self.problem.__str__()
         self.assertEqual(description, 'foo->foo->foo->foo')
-
-    def test_check_type(self):
-        pass

--- a/trane/core/cutoff_strategy.py
+++ b/trane/core/cutoff_strategy.py
@@ -8,10 +8,9 @@ class CutoffStrategy:
 
     Parameters
     ----------
-    generate_fn: a function that generates training and test cutoff times.
+    generate_fn: a function that generates a cutoff time for a given entity.
         input: entity rows
-        output: a tuple with the following timestamps:
-            (training_cutoff, test_cutoff)
+        output: a training cutoff in np.datetime64 format
 
     Returns
     -------
@@ -53,20 +52,20 @@ class CutoffStrategy:
             # a user's generate_fn may expect it
             df_group.set_index(entity_id_col, inplace=True)
 
-            training_cutoff, test_cutoff = None, None
+            cutoff = None
 
             if self.generate_fn:
-                training_cutoff, test_cutoff = self.generate_fn(
+                cutoff = self.generate_fn(
                     df_group, entity_id)
 
             # add this data to a long array
-            val_arr.extend((entity_id, training_cutoff, test_cutoff))
+            val_arr.extend((entity_id, cutoff))
 
         # reshape the array so that it has 3 columns.
         # -1 indicates that the number of rows is inferred
-        data = np.array(val_arr).reshape(-1, 3)
+        data = np.array(val_arr).reshape(-1, 2)
         cutoff_df = pd.DataFrame(
-            data, columns=[entity_id_col, 'training_cutoff', 'test_cutoff'])
+            data, columns=[entity_id_col, 'cutoff'])
         cutoff_df.set_index(entity_id_col, inplace=True)
 
         return cutoff_df

--- a/trane/core/cutoff_strategy.py
+++ b/trane/core/cutoff_strategy.py
@@ -64,8 +64,8 @@ class CutoffStrategy:
         # reshape the array so that it has 3 columns.
         # -1 indicates that the number of rows is inferred
         data = np.array(val_arr).reshape(-1, 2)
-        cutoff_df = pd.DataFrame(
-            data, columns=[entity_id_col, 'cutoff'])
+        cutoff_df = pd.DataFrame(data)
+        cutoff_df.rename(columns={0: entity_id_col, 1: 'cutoff'}, inplace=True)
         cutoff_df.set_index(entity_id_col, inplace=True)
 
         return cutoff_df

--- a/trane/core/prediction_problem.py
+++ b/trane/core/prediction_problem.py
@@ -146,7 +146,7 @@ class PredictionProblem:
     def _rename_columns(self, df, column_list):
         '''
         Renames columns in a given dataframe, in order, as the column_list.
-        The method assumes that
+
         This is required because of support for Python 2.7 and Pandas 0.21
         A more modern way is to pass columns=df.columns
             into pd.DataFrame.from_dict.


### PR DESCRIPTION
- update execute method in prediction problem
  - returns a 3 column dataframe: entity_id, cutoff_time, label
- update cutoff strategy to only return one cutoff_time per entity id
- reimplement surrounding methods and tests